### PR TITLE
Fix warnings about redundant semicolons

### DIFF
--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -132,84 +132,84 @@ namespace sdl
     return callSdl(SDL_##Y, handle, args...);              \
   }
 
-#define SDL_CLASS_METHOD_LIST                     \
-  METHOD(glCreateContext, GL_CreateContext);      \
-  METHOD(glGetDrawableSize, GL_GetDrawableSize);  \
-  METHOD(glMakeCurrent, GL_MakeCurrent);          \
-  METHOD(glSwap, GL_SwapWindow);                  \
-  METHOD(getBrightness, GetWindowBrightness);     \
-  METHOD(getData, GetWindowData);                 \
-  METHOD(getDisplayIndex, GetWindowDisplayIndex); \
-  METHOD(getDisplayMode, GetWindowDisplayMode);   \
-  METHOD(getFlags, GetWindowFlags);               \
-  METHOD(getGammaRamp, GetWindowGammaRamp);       \
-  METHOD(getGrab, GetWindowGrab);                 \
-  METHOD(getID, GetWindowID);                     \
-  METHOD(getMaximumSize, GetWindowMaximumSize);   \
-  METHOD(getMinimumSize, GetWindowMinimumSize);   \
-  METHOD(getPixelFormat, GetWindowPixelFormat);   \
-  METHOD(getPosition, GetWindowPosition);         \
-  METHOD(getSize, GetWindowSize);                 \
-  METHOD(getSurface, GetWindowSurface);           \
-  METHOD(getTitle, GetWindowTitle);               \
-  METHOD(hide, HideWindow);                       \
-  METHOD(maximize, MaximizeWindow);               \
-  METHOD(minimize, MinimizeWindow);               \
-  METHOD(raise, RaiseWindow);                     \
-  METHOD(restore, RestoreWindow);                 \
-  METHOD(setBordered, SetWindowBordered);         \
-  METHOD(setBrightness, SetWindowBrightness);     \
-  METHOD(setData, SetWindowData);                 \
-  METHOD(setDisplayMode, SetWindowDisplayMode);   \
-  METHOD(setFullscreen, SetWindowFullscreen);     \
-  METHOD(setGammaRamp, SetWindowGammaRamp);       \
-  METHOD(setGrab, SetWindowGrab);                 \
-  METHOD(setHitTest, SetWindowHitTest);           \
-  METHOD(setIcon, SetWindowIcon);                 \
-  METHOD(setMaximumSize, SetWindowMaximumSize);   \
-  METHOD(setMinimumSize, SetWindowMinimumSize);   \
-  METHOD(setPosition, SetWindowPosition);         \
-  METHOD(setSize, SetWindowSize);                 \
-  METHOD(setTitle, SetWindowTitle);               \
-  METHOD(show, ShowWindow);                       \
-  METHOD(updateSurface, UpdateWindowSurface);     \
-  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects);
+#define SDL_CLASS_METHOD_LIST                    \
+  METHOD(glCreateContext, GL_CreateContext)      \
+  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
+  METHOD(glMakeCurrent, GL_MakeCurrent)          \
+  METHOD(glSwap, GL_SwapWindow)                  \
+  METHOD(getBrightness, GetWindowBrightness)     \
+  METHOD(getData, GetWindowData)                 \
+  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
+  METHOD(getDisplayMode, GetWindowDisplayMode)   \
+  METHOD(getFlags, GetWindowFlags)               \
+  METHOD(getGammaRamp, GetWindowGammaRamp)       \
+  METHOD(getGrab, GetWindowGrab)                 \
+  METHOD(getID, GetWindowID)                     \
+  METHOD(getMaximumSize, GetWindowMaximumSize)   \
+  METHOD(getMinimumSize, GetWindowMinimumSize)   \
+  METHOD(getPixelFormat, GetWindowPixelFormat)   \
+  METHOD(getPosition, GetWindowPosition)         \
+  METHOD(getSize, GetWindowSize)                 \
+  METHOD(getSurface, GetWindowSurface)           \
+  METHOD(getTitle, GetWindowTitle)               \
+  METHOD(hide, HideWindow)                       \
+  METHOD(maximize, MaximizeWindow)               \
+  METHOD(minimize, MinimizeWindow)               \
+  METHOD(raise, RaiseWindow)                     \
+  METHOD(restore, RestoreWindow)                 \
+  METHOD(setBordered, SetWindowBordered)         \
+  METHOD(setBrightness, SetWindowBrightness)     \
+  METHOD(setData, SetWindowData)                 \
+  METHOD(setDisplayMode, SetWindowDisplayMode)   \
+  METHOD(setFullscreen, SetWindowFullscreen)     \
+  METHOD(setGammaRamp, SetWindowGammaRamp)       \
+  METHOD(setGrab, SetWindowGrab)                 \
+  METHOD(setHitTest, SetWindowHitTest)           \
+  METHOD(setIcon, SetWindowIcon)                 \
+  METHOD(setMaximumSize, SetWindowMaximumSize)   \
+  METHOD(setMinimumSize, SetWindowMinimumSize)   \
+  METHOD(setPosition, SetWindowPosition)         \
+  METHOD(setSize, SetWindowSize)                 \
+  METHOD(setTitle, SetWindowTitle)               \
+  METHOD(show, ShowWindow)                       \
+  METHOD(updateSurface, UpdateWindowSurface)     \
+  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
 
   SDL_CLASS(Window);
 #undef SDL_CLASS_METHOD_LIST
-#define SDL_CLASS_METHOD_LIST                       \
-  METHOD(getDrawBlendMode, GetRenderDrawBlendMode); \
-  METHOD(getDrawColor, GetRenderDrawColor);         \
-  METHOD(getDriverInfo, GetRenderDriverInfo);       \
-  METHOD(getTarget, GetRenderTarget);               \
-  METHOD(getInfo, GetRendererInfo);                 \
-  METHOD(getOutputSize, GetRendererOutputSize);     \
-  METHOD(clear, RenderClear);                       \
-  METHOD(copy, RenderCopy);                         \
-  METHOD(copyEx, RenderCopyEx);                     \
-  METHOD(drawLine, RenderDrawLine);                 \
-  METHOD(drawLines, RenderDrawLines);               \
-  METHOD(drawPoint, RenderDrawPoint);               \
-  METHOD(drawPoints, RenderDrawPoints);             \
-  METHOD(drawRect, RenderDrawRect);                 \
-  METHOD(drawRects, RenderDrawRects);               \
-  METHOD(fillRect, RenderFillRect);                 \
-  METHOD(fillRects, RenderFillRects);               \
-  METHOD(getClipRect, RenderGetClipRect);           \
-  METHOD(getLogicalSize, RenderGetLogicalSize);     \
-  METHOD(getScale, RenderGetScale);                 \
-  METHOD(getViewport, RenderGetViewport);           \
-  METHOD(isClipEnabled, RenderIsClipEnabled);       \
-  METHOD(present, RenderPresent);                   \
-  METHOD(readPixels, RenderReadPixels);             \
-  METHOD(setClipRect, RenderSetClipRect);           \
-  METHOD(setLogicalSize, RenderSetLogicalSize);     \
-  METHOD(setScale, RenderSetScale);                 \
-  METHOD(setViewport, RenderSetViewport);           \
-  METHOD(targetSupported, RenderTargetSupported);   \
-  METHOD(setDrawBlendMode, SetRenderDrawBlendMode); \
-  METHOD(setDrawColor, SetRenderDrawColor);         \
-  METHOD(setTarget, SetRenderTarget);
+#define SDL_CLASS_METHOD_LIST                      \
+  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
+  METHOD(getDrawColor, GetRenderDrawColor)         \
+  METHOD(getDriverInfo, GetRenderDriverInfo)       \
+  METHOD(getTarget, GetRenderTarget)               \
+  METHOD(getInfo, GetRendererInfo)                 \
+  METHOD(getOutputSize, GetRendererOutputSize)     \
+  METHOD(clear, RenderClear)                       \
+  METHOD(copy, RenderCopy)                         \
+  METHOD(copyEx, RenderCopyEx)                     \
+  METHOD(drawLine, RenderDrawLine)                 \
+  METHOD(drawLines, RenderDrawLines)               \
+  METHOD(drawPoint, RenderDrawPoint)               \
+  METHOD(drawPoints, RenderDrawPoints)             \
+  METHOD(drawRect, RenderDrawRect)                 \
+  METHOD(drawRects, RenderDrawRects)               \
+  METHOD(fillRect, RenderFillRect)                 \
+  METHOD(fillRects, RenderFillRects)               \
+  METHOD(getClipRect, RenderGetClipRect)           \
+  METHOD(getLogicalSize, RenderGetLogicalSize)     \
+  METHOD(getScale, RenderGetScale)                 \
+  METHOD(getViewport, RenderGetViewport)           \
+  METHOD(isClipEnabled, RenderIsClipEnabled)       \
+  METHOD(present, RenderPresent)                   \
+  METHOD(readPixels, RenderReadPixels)             \
+  METHOD(setClipRect, RenderSetClipRect)           \
+  METHOD(setLogicalSize, RenderSetLogicalSize)     \
+  METHOD(setScale, RenderSetScale)                 \
+  METHOD(setViewport, RenderSetViewport)           \
+  METHOD(targetSupported, RenderTargetSupported)   \
+  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
+  METHOD(setDrawColor, SetRenderDrawColor)         \
+  METHOD(setTarget, SetRenderTarget)
   SDL_CLASS(Renderer);
 
 #undef SDL_CLASS_METHOD_LIST
@@ -224,19 +224,19 @@ namespace sdl
       throw Error(strm.str());                                \
     }                                                         \
   }                                                           \
-  METHOD(glBind, GL_BindTexture);                             \
-  METHOD(glUnbind, GL_UnbindTexture);                         \
-  METHOD(getAlphaMod, GetTextureAlphaMod);                    \
-  METHOD(getBlendMode, GetTextureBlendMode);                  \
-  METHOD(getColorMod, GetTextureColorMod);                    \
-  METHOD(lock, LockTexture);                                  \
-  METHOD(query, QueryTexture);                                \
-  METHOD(setAlphaMod, SetTextureAlphaMod);                    \
-  METHOD(setBlendMode, SetTextureBlendMode);                  \
-  METHOD(setColorMod, SetTextureColorMod);                    \
-  METHOD(unlock, UnlockTexture);                              \
-  METHOD(update, UpdateTexture);                              \
-  METHOD(updateYuv, UpdateYUVTexture);
+  METHOD(glBind, GL_BindTexture)                              \
+  METHOD(glUnbind, GL_UnbindTexture)                          \
+  METHOD(getAlphaMod, GetTextureAlphaMod)                     \
+  METHOD(getBlendMode, GetTextureBlendMode)                   \
+  METHOD(getColorMod, GetTextureColorMod)                     \
+  METHOD(lock, LockTexture)                                   \
+  METHOD(query, QueryTexture)                                 \
+  METHOD(setAlphaMod, SetTextureAlphaMod)                     \
+  METHOD(setBlendMode, SetTextureBlendMode)                   \
+  METHOD(setColorMod, SetTextureColorMod)                     \
+  METHOD(unlock, UnlockTexture)                               \
+  METHOD(update, UpdateTexture)                               \
+  METHOD(updateYuv, UpdateYUVTexture)
   SDL_CLASS(Texture);
 
   class Surface
@@ -286,20 +286,20 @@ namespace sdl
     SDL_Surface *handle;
 
   public:
-    METHOD(setPalette, SetSurfacePalette);
-    METHOD(lock, LockSurface);
-    METHOD(unlock, UnlockSurface);
-    METHOD(setColorKey, SetColorKey);
-    METHOD(getColorKey, GetColorKey);
-    METHOD(setColorMode, SetSurfaceColorMod);
-    METHOD(getColorMode, GetSurfaceColorMod);
-    METHOD(setClipRect, SetClipRect);
-    METHOD(getClipRect, GetClipRect);
-    METHOD(fillRect, FillRect);
-    METHOD(fillRects, FillRects);
-    METHOD(blit, BlitSurface);
-    METHOD(softStretch, SoftStretch);
-    METHOD(blitScaled, BlitScaled);
+    METHOD(setPalette, SetSurfacePalette)
+    METHOD(lock, LockSurface)
+    METHOD(unlock, UnlockSurface)
+    METHOD(setColorKey, SetColorKey)
+    METHOD(getColorKey, GetColorKey)
+    METHOD(setColorMode, SetSurfaceColorMod)
+    METHOD(getColorMode, GetSurfaceColorMod)
+    METHOD(setClipRect, SetClipRect)
+    METHOD(getClipRect, GetClipRect)
+    METHOD(fillRect, FillRect)
+    METHOD(fillRects, FillRects)
+    METHOD(blit, BlitSurface)
+    METHOD(softStretch, SoftStretch)
+    METHOD(blitScaled, BlitScaled)
   };
 
   class Audio
@@ -353,13 +353,12 @@ namespace sdl
     }
 
   public:
-    METHOD(clearQueued, ClearQueuedAudio);
-    METHOD(getStatus, GetAudioDeviceStatus);
-    METHOD(getQueuedSize, GetQueuedAudioSize);
-    METHOD(lock, LockAudioDevice);
-    METHOD(pause, PauseAudioDevice)
-    METHOD(queue, QueueAudio);
-    METHOD(unlock, UnlockAudioDevice);
+    METHOD(clearQueued, ClearQueuedAudio)
+    METHOD(getStatus, GetAudioDeviceStatus)
+    METHOD(getQueuedSize, GetQueuedAudioSize)
+    METHOD(lock, LockAudioDevice)
+    METHOD(pause, PauseAudioDevice)    METHOD(queue, QueueAudio)
+    METHOD(unlock, UnlockAudioDevice)
   };
   class EventHandler
   {


### PR DESCRIPTION
GCC produces a lot of warnings about redundant semicolons. Removing semicolon from each use of METHOD macro solves this issue.

Note that the semicolon is in not needed, because METHOD macro extends into method definition which should not end with semicolon.