### PR TITLE
Reduce code duplication

### DIFF
--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -132,166 +132,101 @@ namespace sdl
     return callSdl(SDL_##Y, handle, args...);              \
   }
 
+#define SDL_CLASS_METHOD_LIST_TMP                \
+  METHOD(glCreateContext, GL_CreateContext)      \
+  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
+  METHOD(glMakeCurrent, GL_MakeCurrent)          \
+  METHOD(glSwap, GL_SwapWindow)                  \
+  METHOD(getBrightness, GetWindowBrightness)     \
+  METHOD(getData, GetWindowData)                 \
+  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
+  METHOD(getDisplayMode, GetWindowDisplayMode)   \
+  METHOD(getFlags, GetWindowFlags)               \
+  METHOD(getGammaRamp, GetWindowGammaRamp)       \
+  METHOD(getGrab, GetWindowGrab)                 \
+  METHOD(getID, GetWindowID)                     \
+  METHOD(getMaximumSize, GetWindowMaximumSize)   \
+  METHOD(getMinimumSize, GetWindowMinimumSize)   \
+  METHOD(getPixelFormat, GetWindowPixelFormat)   \
+  METHOD(getPosition, GetWindowPosition)         \
+  METHOD(getSize, GetWindowSize)                 \
+  METHOD(getSurface, GetWindowSurface)           \
+  METHOD(getTitle, GetWindowTitle)               \
+  METHOD(hide, HideWindow)                       \
+  METHOD(maximize, MaximizeWindow)               \
+  METHOD(minimize, MinimizeWindow)               \
+  METHOD(raise, RaiseWindow)                     \
+  METHOD(restore, RestoreWindow)                 \
+  METHOD(setBordered, SetWindowBordered)         \
+  METHOD(setBrightness, SetWindowBrightness)     \
+  METHOD(setData, SetWindowData)                 \
+  METHOD(setDisplayMode, SetWindowDisplayMode)   \
+  METHOD(setFullscreen, SetWindowFullscreen)     \
+  METHOD(setGammaRamp, SetWindowGammaRamp)       \
+  METHOD(setGrab, SetWindowGrab)                 \
+  METHOD(setIcon, SetWindowIcon)                 \
+  METHOD(setMaximumSize, SetWindowMaximumSize)   \
+  METHOD(setMinimumSize, SetWindowMinimumSize)   \
+  METHOD(setPosition, SetWindowPosition)         \
+  METHOD(setSize, SetWindowSize)                 \
+  METHOD(setTitle, SetWindowTitle)               \
+  METHOD(show, ShowWindow)                       \
+  METHOD(updateSurface, UpdateWindowSurface)     \
+  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
 #if SDL_COMPILEDVERSION < 2004
 #define SDL_CLASS_METHOD_LIST                    \
-  METHOD(glCreateContext, GL_CreateContext)      \
-  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
-  METHOD(glMakeCurrent, GL_MakeCurrent)          \
-  METHOD(glSwap, GL_SwapWindow)                  \
-  METHOD(getBrightness, GetWindowBrightness)     \
-  METHOD(getData, GetWindowData)                 \
-  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
-  METHOD(getDisplayMode, GetWindowDisplayMode)   \
-  METHOD(getFlags, GetWindowFlags)               \
-  METHOD(getGammaRamp, GetWindowGammaRamp)       \
-  METHOD(getGrab, GetWindowGrab)                 \
-  METHOD(getID, GetWindowID)                     \
-  METHOD(getMaximumSize, GetWindowMaximumSize)   \
-  METHOD(getMinimumSize, GetWindowMinimumSize)   \
-  METHOD(getPixelFormat, GetWindowPixelFormat)   \
-  METHOD(getPosition, GetWindowPosition)         \
-  METHOD(getSize, GetWindowSize)                 \
-  METHOD(getSurface, GetWindowSurface)           \
-  METHOD(getTitle, GetWindowTitle)               \
-  METHOD(hide, HideWindow)                       \
-  METHOD(maximize, MaximizeWindow)               \
-  METHOD(minimize, MinimizeWindow)               \
-  METHOD(raise, RaiseWindow)                     \
-  METHOD(restore, RestoreWindow)                 \
-  METHOD(setBordered, SetWindowBordered)         \
-  METHOD(setBrightness, SetWindowBrightness)     \
-  METHOD(setData, SetWindowData)                 \
-  METHOD(setDisplayMode, SetWindowDisplayMode)   \
-  METHOD(setFullscreen, SetWindowFullscreen)     \
-  METHOD(setGammaRamp, SetWindowGammaRamp)       \
-  METHOD(setGrab, SetWindowGrab)                 \
-  METHOD(setIcon, SetWindowIcon)                 \
-  METHOD(setMaximumSize, SetWindowMaximumSize)   \
-  METHOD(setMinimumSize, SetWindowMinimumSize)   \
-  METHOD(setPosition, SetWindowPosition)         \
-  METHOD(setSize, SetWindowSize)                 \
-  METHOD(setTitle, SetWindowTitle)               \
-  METHOD(show, ShowWindow)                       \
-  METHOD(updateSurface, UpdateWindowSurface)     \
-  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
+  SDL_CLASS_METHOD_LIST_TMP
 #else
 #define SDL_CLASS_METHOD_LIST                    \
-  METHOD(glCreateContext, GL_CreateContext)      \
-  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
-  METHOD(glMakeCurrent, GL_MakeCurrent)          \
-  METHOD(glSwap, GL_SwapWindow)                  \
-  METHOD(getBrightness, GetWindowBrightness)     \
-  METHOD(getData, GetWindowData)                 \
-  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
-  METHOD(getDisplayMode, GetWindowDisplayMode)   \
-  METHOD(getFlags, GetWindowFlags)               \
-  METHOD(getGammaRamp, GetWindowGammaRamp)       \
-  METHOD(getGrab, GetWindowGrab)                 \
-  METHOD(getID, GetWindowID)                     \
-  METHOD(getMaximumSize, GetWindowMaximumSize)   \
-  METHOD(getMinimumSize, GetWindowMinimumSize)   \
-  METHOD(getPixelFormat, GetWindowPixelFormat)   \
-  METHOD(getPosition, GetWindowPosition)         \
-  METHOD(getSize, GetWindowSize)                 \
-  METHOD(getSurface, GetWindowSurface)           \
-  METHOD(getTitle, GetWindowTitle)               \
-  METHOD(hide, HideWindow)                       \
-  METHOD(maximize, MaximizeWindow)               \
-  METHOD(minimize, MinimizeWindow)               \
-  METHOD(raise, RaiseWindow)                     \
-  METHOD(restore, RestoreWindow)                 \
-  METHOD(setBordered, SetWindowBordered)         \
-  METHOD(setBrightness, SetWindowBrightness)     \
-  METHOD(setData, SetWindowData)                 \
-  METHOD(setDisplayMode, SetWindowDisplayMode)   \
-  METHOD(setFullscreen, SetWindowFullscreen)     \
-  METHOD(setGammaRamp, SetWindowGammaRamp)       \
-  METHOD(setGrab, SetWindowGrab)                 \
-  METHOD(setHitTest, SetWindowHitTest)           \
-  METHOD(setIcon, SetWindowIcon)                 \
-  METHOD(setMaximumSize, SetWindowMaximumSize)   \
-  METHOD(setMinimumSize, SetWindowMinimumSize)   \
-  METHOD(setPosition, SetWindowPosition)         \
-  METHOD(setSize, SetWindowSize)                 \
-  METHOD(setTitle, SetWindowTitle)               \
-  METHOD(show, ShowWindow)                       \
-  METHOD(updateSurface, UpdateWindowSurface)     \
-  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
+  SDL_CLASS_METHOD_LIST_TMP                      \
+  METHOD(setHitTest, SetWindowHitTest)
 #endif
 
   SDL_CLASS(Window);
 #undef SDL_CLASS_METHOD_LIST
+#undef SDL_CLASS_METHOD_LIST_TMP
+
+#define SDL_CLASS_METHOD_LIST_TMP                  \
+  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
+  METHOD(getDrawColor, GetRenderDrawColor)         \
+  METHOD(getDriverInfo, GetRenderDriverInfo)       \
+  METHOD(getTarget, GetRenderTarget)               \
+  METHOD(getInfo, GetRendererInfo)                 \
+  METHOD(getOutputSize, GetRendererOutputSize)     \
+  METHOD(clear, RenderClear)                       \
+  METHOD(copy, RenderCopy)                         \
+  METHOD(copyEx, RenderCopyEx)                     \
+  METHOD(drawLine, RenderDrawLine)                 \
+  METHOD(drawLines, RenderDrawLines)               \
+  METHOD(drawPoint, RenderDrawPoint)               \
+  METHOD(drawPoints, RenderDrawPoints)             \
+  METHOD(drawRect, RenderDrawRect)                 \
+  METHOD(drawRects, RenderDrawRects)               \
+  METHOD(fillRect, RenderFillRect)                 \
+  METHOD(fillRects, RenderFillRects)               \
+  METHOD(getClipRect, RenderGetClipRect)           \
+  METHOD(getLogicalSize, RenderGetLogicalSize)     \
+  METHOD(getScale, RenderGetScale)                 \
+  METHOD(getViewport, RenderGetViewport)           \
+  METHOD(present, RenderPresent)                   \
+  METHOD(readPixels, RenderReadPixels)             \
+  METHOD(setClipRect, RenderSetClipRect)           \
+  METHOD(setLogicalSize, RenderSetLogicalSize)     \
+  METHOD(setScale, RenderSetScale)                 \
+  METHOD(setViewport, RenderSetViewport)           \
+  METHOD(targetSupported, RenderTargetSupported)   \
+  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
+  METHOD(setDrawColor, SetRenderDrawColor)         \
+  METHOD(setTarget, SetRenderTarget)
 
 #if SDL_COMPILEDVERSION < 2004
 #define SDL_CLASS_METHOD_LIST                      \
-  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
-  METHOD(getDrawColor, GetRenderDrawColor)         \
-  METHOD(getDriverInfo, GetRenderDriverInfo)       \
-  METHOD(getTarget, GetRenderTarget)               \
-  METHOD(getInfo, GetRendererInfo)                 \
-  METHOD(getOutputSize, GetRendererOutputSize)     \
-  METHOD(clear, RenderClear)                       \
-  METHOD(copy, RenderCopy)                         \
-  METHOD(copyEx, RenderCopyEx)                     \
-  METHOD(drawLine, RenderDrawLine)                 \
-  METHOD(drawLines, RenderDrawLines)               \
-  METHOD(drawPoint, RenderDrawPoint)               \
-  METHOD(drawPoints, RenderDrawPoints)             \
-  METHOD(drawRect, RenderDrawRect)                 \
-  METHOD(drawRects, RenderDrawRects)               \
-  METHOD(fillRect, RenderFillRect)                 \
-  METHOD(fillRects, RenderFillRects)               \
-  METHOD(getClipRect, RenderGetClipRect)           \
-  METHOD(getLogicalSize, RenderGetLogicalSize)     \
-  METHOD(getScale, RenderGetScale)                 \
-  METHOD(getViewport, RenderGetViewport)           \
-  METHOD(present, RenderPresent)                   \
-  METHOD(readPixels, RenderReadPixels)             \
-  METHOD(setClipRect, RenderSetClipRect)           \
-  METHOD(setLogicalSize, RenderSetLogicalSize)     \
-  METHOD(setScale, RenderSetScale)                 \
-  METHOD(setViewport, RenderSetViewport)           \
-  METHOD(targetSupported, RenderTargetSupported)   \
-  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
-  METHOD(setDrawColor, SetRenderDrawColor)         \
-  METHOD(setTarget, SetRenderTarget)
+  SDL_CLASS_METHOD_LIST_TMP
   SDL_CLASS(Renderer);
-
 #else
-
 #define SDL_CLASS_METHOD_LIST                      \
-  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
-  METHOD(getDrawColor, GetRenderDrawColor)         \
-  METHOD(getDriverInfo, GetRenderDriverInfo)       \
-  METHOD(getTarget, GetRenderTarget)               \
-  METHOD(getInfo, GetRendererInfo)                 \
-  METHOD(getOutputSize, GetRendererOutputSize)     \
-  METHOD(clear, RenderClear)                       \
-  METHOD(copy, RenderCopy)                         \
-  METHOD(copyEx, RenderCopyEx)                     \
-  METHOD(drawLine, RenderDrawLine)                 \
-  METHOD(drawLines, RenderDrawLines)               \
-  METHOD(drawPoint, RenderDrawPoint)               \
-  METHOD(drawPoints, RenderDrawPoints)             \
-  METHOD(drawRect, RenderDrawRect)                 \
-  METHOD(drawRects, RenderDrawRects)               \
-  METHOD(fillRect, RenderFillRect)                 \
-  METHOD(fillRects, RenderFillRects)               \
-  METHOD(getClipRect, RenderGetClipRect)           \
-  METHOD(getLogicalSize, RenderGetLogicalSize)     \
-  METHOD(getScale, RenderGetScale)                 \
-  METHOD(getViewport, RenderGetViewport)           \
-  METHOD(isClipEnabled, RenderIsClipEnabled)       \
-  METHOD(present, RenderPresent)                   \
-  METHOD(readPixels, RenderReadPixels)             \
-  METHOD(setClipRect, RenderSetClipRect)           \
-  METHOD(setLogicalSize, RenderSetLogicalSize)     \
-  METHOD(setScale, RenderSetScale)                 \
-  METHOD(setViewport, RenderSetViewport)           \
-  METHOD(targetSupported, RenderTargetSupported)   \
-  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
-  METHOD(setDrawColor, SetRenderDrawColor)         \
-  METHOD(setTarget, SetRenderTarget)
+  SDL_CLASS_METHOD_LIST_TMP                        \
+  METHOD(isClipEnabled, RenderIsClipEnabled)
   SDL_CLASS(Renderer);
 #endif
 
@@ -477,8 +412,7 @@ namespace sdl
         throw Error(strm.str());
       }
     }
-#if SDL_COMPILEDVERSION < 2004
-#define SDL_EVENTS                                                        \
+#define SDL_EVENTS_TMP                                                    \
   EVENT(SDL_CONTROLLERAXISMOTION, controllerAxisMotion, caxis);           \
   EVENT(SDL_CONTROLLERBUTTONDOWN, controllerButtonDown, cbutton);         \
   EVENT(SDL_CONTROLLERBUTTONUP, controllerButtonUp, cbutton);             \
@@ -511,42 +445,13 @@ namespace sdl
   EVENT(SDL_TEXTINPUT, textInput, text);                                  \
   EVENT(SDL_USEREVENT, userEvent, user);                                  \
   EVENT(SDL_WINDOWEVENT, windowEvent, window);
+#if SDL_COMPILEDVERSION < 2004
+#define SDL_EVENTS SDL_EVENTS_TMP
 #else
 #define SDL_EVENTS                                                        \
+  SDL_EVENTS_TMP                                                          \
   EVENT(SDL_AUDIODEVICEADDED, audioDeviceAdded, adevice);                 \
-  EVENT(SDL_AUDIODEVICEREMOVED, audioDeviceRemoved, adevice);             \
-  EVENT(SDL_CONTROLLERAXISMOTION, controllerAxisMotion, caxis);           \
-  EVENT(SDL_CONTROLLERBUTTONDOWN, controllerButtonDown, cbutton);         \
-  EVENT(SDL_CONTROLLERBUTTONUP, controllerButtonUp, cbutton);             \
-  EVENT(SDL_CONTROLLERDEVICEADDED, controllerDeviceAdded, cdevice);       \
-  EVENT(SDL_CONTROLLERDEVICEREMOVED, controllerDeviceRemoved, cdevice);   \
-  EVENT(SDL_CONTROLLERDEVICEREMAPPED, controllerDeviceRemapped, cdevice); \
-  EVENT(SDL_DOLLARGESTURE, dollarGesture, dgesture);                      \
-  EVENT(SDL_DOLLARRECORD, dollarRecord, dgesture);                        \
-  EVENT(SDL_DROPFILE, dropFile, drop);                                    \
-  EVENT(SDL_FINGERMOTION, fingerMotion, tfinger);                         \
-  EVENT(SDL_FINGERDOWN, fingerDown, tfinger);                             \
-  EVENT(SDL_FINGERUP, fingerUp, tfinger);                                 \
-  EVENT(SDL_KEYDOWN, keyDown, key);                                       \
-  EVENT(SDL_KEYUP, keyUp, key);                                           \
-  EVENT(SDL_JOYAXISMOTION, joyAxisMotion, jaxis);                         \
-  EVENT(SDL_JOYBALLMOTION, joyBallMotion, jball);                         \
-  EVENT(SDL_JOYHATMOTION, joyHatMotion, jhat);                            \
-  EVENT(SDL_JOYBUTTONDOWN, joyButtonDown, jbutton);                       \
-  EVENT(SDL_JOYBUTTONUP, joyButtonUp, jbutton);                           \
-  EVENT(SDL_JOYDEVICEADDED, joyDeviceAdded, jdevice);                     \
-  EVENT(SDL_JOYDEVICEREMOVED, joyDeviceRemoved, jdevice);                 \
-  EVENT(SDL_MOUSEMOTION, mouseMotion, motion);                            \
-  EVENT(SDL_MOUSEBUTTONDOWN, mouseButtonDown, button);                    \
-  EVENT(SDL_MOUSEBUTTONUP, mouseButtonUp, button);                        \
-  EVENT(SDL_MOUSEWHEEL, mouseWheel, wheel);                               \
-  EVENT(SDL_MULTIGESTURE, multiGesture, mgesture);                        \
-  EVENT(SDL_QUIT, quit, quit);                                            \
-  EVENT(SDL_SYSWMEVENT, sysWmEvent, syswm);                               \
-  EVENT(SDL_TEXTEDITING, textEditing, edit);                              \
-  EVENT(SDL_TEXTINPUT, textInput, text);                                  \
-  EVENT(SDL_USEREVENT, userEvent, user);                                  \
-  EVENT(SDL_WINDOWEVENT, windowEvent, window);
+  EVENT(SDL_AUDIODEVICEREMOVED, audioDeviceRemoved, adevice);
 #endif
 
 #define EVENT(x, y, z) std::function<void(const decltype(SDL_Event::z) &)> y


### PR DESCRIPTION
Some lengthy `SDL_CLASS_METHOD_LIST`s are duplicated, because if `SDL_COMPILEDVERSION < 2004`, one or two lines need to be removed.

This patch reduces the code duplication by putting the common `METHOD`s into a separate `SDL_CLASS_METHOD_LIST_TMP` macro, which is used to build the actual `SDL_CLASS_METHOD_LIST`. Same thing for `SDL_EVENTS`.

This should change nothing but some method ordering, while making the code cleaner.

Pull request #5 depends on these changes and is a superset of this patchset here.