### PR TITLE
Add support for SDL2_gfx

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Header only C++ wrapper for SDL2.
 
 The library leverages RAII and error handling with exceptions.
 
+Optional support for SDL2_gfx's graphic primitives is available. To turn it on, uncomment the
+`#define USE_SDLGFX` directive in `sdlpp.hpp`.
+
 SDL2 code
 ```c++
   int res = SDL_Init(SDL_INIT_EVERYTHING);
@@ -117,6 +120,67 @@ Also I mapped functions to methods.
 |setDrawBlendMode|SDL_SetRenderDrawBlendMode|
 |setDrawColor|SDL_SetRenderDrawColor|
 |setTarget|SDL_SetRenderTarget|
+
+## Renderer if SDL2_gfx-support is enabled
+|Method|SDL2_gfx function|
+|------|-----------------|
+|pixelColor|pixelColor|
+|pixelRGBA|pixelRGBA|
+|hlineColor|hlineColor|
+|hlineRGBA|hlineRGBA|
+|vlineColor|vlineColor|
+|vlineRGBA|vlineRGBA|
+|rectangleColor|rectangleColor|
+|rectangleRGBA|rectangleRGBA|
+|roundedRectangleColor|roundedRectangleColor|
+|roundedRectangleRGBA|roundedRectangleRGBA|
+|boxColor|boxColor|
+|boxRGBA|boxRGBA|
+|roundedBoxColor|roundedBoxColor|
+|roundedBoxRGBA|roundedBoxRGBA|
+|lineColor|lineColor|
+|lineRGBA|lineRGBA|
+|aalineColor|aalineColor|
+|aalineRGBA|aalineRGBA|
+|thickLineColor|thickLineColor|
+|thickLineRGBA|thickLineRGBA|
+|circleColor|circleColor|
+|circleRGBA|circleRGBA|
+|arcColor|arcColor|
+|arcRGBA|arcRGBA|
+|aacircleColor|aacircleColor|
+|aacircleRGBA|aacircleRGBA|
+|filledCircleColor|filledCircleColor|
+|filledCircleRGBA|filledCircleRGBA|
+|ellipseColor|ellipseColor|
+|ellipseRGBA|ellipseRGBA|
+|aaellipseColor|aaellipseColor|
+|aaellipseRGBA|aaellipseRGBA|
+|filledEllipseColor|filledEllipseColor|
+|filledEllipseRGBA|filledEllipseRGBA|
+|pieColor|pieColor|
+|pieRGBA|pieRGBA|
+|filledPieColor|filledPieColor|
+|filledPieRGBA|filledPieRGBA|
+|trigonColor|trigonColor|
+|trigonRGBA|trigonRGBA|
+|aatrigonColor|aatrigonColor|
+|aatrigonRGBA|aatrigonRGBA|
+|filledTrigonColor|filledTrigonColor|
+|filledTrigonRGBA|filledTrigonRGBA|
+|polygonColor|polygonColor|
+|polygonRGBA|polygonRGBA|
+|aapolygonColor|aapolygonColor|
+|aapolygonRGBA|aapolygonRGBA|
+|filledPolygonColor|filledPolygonColor|
+|filledPolygonRGBA|filledPolygonRGBA|
+|texturedPolygon|texturedPolygon|
+|bezierColor|bezierColor|
+|bezierRGBA|bezierRGBA|
+|characterColor|characterColor|
+|characterRGBA|characterRGBA|
+|stringColor|stringColor|
+|stringRGBA|stringRGBA|
 
 ## Texture
 |Method|SDL2 function|

--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -132,166 +132,101 @@ namespace sdl
     return callSdl(SDL_##Y, handle, args...);              \
   }
 
+#define SDL_CLASS_METHOD_LIST_TMP                \
+  METHOD(glCreateContext, GL_CreateContext)      \
+  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
+  METHOD(glMakeCurrent, GL_MakeCurrent)          \
+  METHOD(glSwap, GL_SwapWindow)                  \
+  METHOD(getBrightness, GetWindowBrightness)     \
+  METHOD(getData, GetWindowData)                 \
+  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
+  METHOD(getDisplayMode, GetWindowDisplayMode)   \
+  METHOD(getFlags, GetWindowFlags)               \
+  METHOD(getGammaRamp, GetWindowGammaRamp)       \
+  METHOD(getGrab, GetWindowGrab)                 \
+  METHOD(getID, GetWindowID)                     \
+  METHOD(getMaximumSize, GetWindowMaximumSize)   \
+  METHOD(getMinimumSize, GetWindowMinimumSize)   \
+  METHOD(getPixelFormat, GetWindowPixelFormat)   \
+  METHOD(getPosition, GetWindowPosition)         \
+  METHOD(getSize, GetWindowSize)                 \
+  METHOD(getSurface, GetWindowSurface)           \
+  METHOD(getTitle, GetWindowTitle)               \
+  METHOD(hide, HideWindow)                       \
+  METHOD(maximize, MaximizeWindow)               \
+  METHOD(minimize, MinimizeWindow)               \
+  METHOD(raise, RaiseWindow)                     \
+  METHOD(restore, RestoreWindow)                 \
+  METHOD(setBordered, SetWindowBordered)         \
+  METHOD(setBrightness, SetWindowBrightness)     \
+  METHOD(setData, SetWindowData)                 \
+  METHOD(setDisplayMode, SetWindowDisplayMode)   \
+  METHOD(setFullscreen, SetWindowFullscreen)     \
+  METHOD(setGammaRamp, SetWindowGammaRamp)       \
+  METHOD(setGrab, SetWindowGrab)                 \
+  METHOD(setIcon, SetWindowIcon)                 \
+  METHOD(setMaximumSize, SetWindowMaximumSize)   \
+  METHOD(setMinimumSize, SetWindowMinimumSize)   \
+  METHOD(setPosition, SetWindowPosition)         \
+  METHOD(setSize, SetWindowSize)                 \
+  METHOD(setTitle, SetWindowTitle)               \
+  METHOD(show, ShowWindow)                       \
+  METHOD(updateSurface, UpdateWindowSurface)     \
+  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
 #if SDL_COMPILEDVERSION < 2004
 #define SDL_CLASS_METHOD_LIST                    \
-  METHOD(glCreateContext, GL_CreateContext)      \
-  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
-  METHOD(glMakeCurrent, GL_MakeCurrent)          \
-  METHOD(glSwap, GL_SwapWindow)                  \
-  METHOD(getBrightness, GetWindowBrightness)     \
-  METHOD(getData, GetWindowData)                 \
-  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
-  METHOD(getDisplayMode, GetWindowDisplayMode)   \
-  METHOD(getFlags, GetWindowFlags)               \
-  METHOD(getGammaRamp, GetWindowGammaRamp)       \
-  METHOD(getGrab, GetWindowGrab)                 \
-  METHOD(getID, GetWindowID)                     \
-  METHOD(getMaximumSize, GetWindowMaximumSize)   \
-  METHOD(getMinimumSize, GetWindowMinimumSize)   \
-  METHOD(getPixelFormat, GetWindowPixelFormat)   \
-  METHOD(getPosition, GetWindowPosition)         \
-  METHOD(getSize, GetWindowSize)                 \
-  METHOD(getSurface, GetWindowSurface)           \
-  METHOD(getTitle, GetWindowTitle)               \
-  METHOD(hide, HideWindow)                       \
-  METHOD(maximize, MaximizeWindow)               \
-  METHOD(minimize, MinimizeWindow)               \
-  METHOD(raise, RaiseWindow)                     \
-  METHOD(restore, RestoreWindow)                 \
-  METHOD(setBordered, SetWindowBordered)         \
-  METHOD(setBrightness, SetWindowBrightness)     \
-  METHOD(setData, SetWindowData)                 \
-  METHOD(setDisplayMode, SetWindowDisplayMode)   \
-  METHOD(setFullscreen, SetWindowFullscreen)     \
-  METHOD(setGammaRamp, SetWindowGammaRamp)       \
-  METHOD(setGrab, SetWindowGrab)                 \
-  METHOD(setIcon, SetWindowIcon)                 \
-  METHOD(setMaximumSize, SetWindowMaximumSize)   \
-  METHOD(setMinimumSize, SetWindowMinimumSize)   \
-  METHOD(setPosition, SetWindowPosition)         \
-  METHOD(setSize, SetWindowSize)                 \
-  METHOD(setTitle, SetWindowTitle)               \
-  METHOD(show, ShowWindow)                       \
-  METHOD(updateSurface, UpdateWindowSurface)     \
-  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
+  SDL_CLASS_METHOD_LIST_TMP
 #else
 #define SDL_CLASS_METHOD_LIST                    \
-  METHOD(glCreateContext, GL_CreateContext)      \
-  METHOD(glGetDrawableSize, GL_GetDrawableSize)  \
-  METHOD(glMakeCurrent, GL_MakeCurrent)          \
-  METHOD(glSwap, GL_SwapWindow)                  \
-  METHOD(getBrightness, GetWindowBrightness)     \
-  METHOD(getData, GetWindowData)                 \
-  METHOD(getDisplayIndex, GetWindowDisplayIndex) \
-  METHOD(getDisplayMode, GetWindowDisplayMode)   \
-  METHOD(getFlags, GetWindowFlags)               \
-  METHOD(getGammaRamp, GetWindowGammaRamp)       \
-  METHOD(getGrab, GetWindowGrab)                 \
-  METHOD(getID, GetWindowID)                     \
-  METHOD(getMaximumSize, GetWindowMaximumSize)   \
-  METHOD(getMinimumSize, GetWindowMinimumSize)   \
-  METHOD(getPixelFormat, GetWindowPixelFormat)   \
-  METHOD(getPosition, GetWindowPosition)         \
-  METHOD(getSize, GetWindowSize)                 \
-  METHOD(getSurface, GetWindowSurface)           \
-  METHOD(getTitle, GetWindowTitle)               \
-  METHOD(hide, HideWindow)                       \
-  METHOD(maximize, MaximizeWindow)               \
-  METHOD(minimize, MinimizeWindow)               \
-  METHOD(raise, RaiseWindow)                     \
-  METHOD(restore, RestoreWindow)                 \
-  METHOD(setBordered, SetWindowBordered)         \
-  METHOD(setBrightness, SetWindowBrightness)     \
-  METHOD(setData, SetWindowData)                 \
-  METHOD(setDisplayMode, SetWindowDisplayMode)   \
-  METHOD(setFullscreen, SetWindowFullscreen)     \
-  METHOD(setGammaRamp, SetWindowGammaRamp)       \
-  METHOD(setGrab, SetWindowGrab)                 \
-  METHOD(setHitTest, SetWindowHitTest)           \
-  METHOD(setIcon, SetWindowIcon)                 \
-  METHOD(setMaximumSize, SetWindowMaximumSize)   \
-  METHOD(setMinimumSize, SetWindowMinimumSize)   \
-  METHOD(setPosition, SetWindowPosition)         \
-  METHOD(setSize, SetWindowSize)                 \
-  METHOD(setTitle, SetWindowTitle)               \
-  METHOD(show, ShowWindow)                       \
-  METHOD(updateSurface, UpdateWindowSurface)     \
-  METHOD(updateSurfaceRects, UpdateWindowSurfaceRects)
+  SDL_CLASS_METHOD_LIST_TMP                      \
+  METHOD(setHitTest, SetWindowHitTest)
 #endif
 
   SDL_CLASS(Window);
 #undef SDL_CLASS_METHOD_LIST
+#undef SDL_CLASS_METHOD_LIST_TMP
+
+#define SDL_CLASS_METHOD_LIST_TMP                  \
+  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
+  METHOD(getDrawColor, GetRenderDrawColor)         \
+  METHOD(getDriverInfo, GetRenderDriverInfo)       \
+  METHOD(getTarget, GetRenderTarget)               \
+  METHOD(getInfo, GetRendererInfo)                 \
+  METHOD(getOutputSize, GetRendererOutputSize)     \
+  METHOD(clear, RenderClear)                       \
+  METHOD(copy, RenderCopy)                         \
+  METHOD(copyEx, RenderCopyEx)                     \
+  METHOD(drawLine, RenderDrawLine)                 \
+  METHOD(drawLines, RenderDrawLines)               \
+  METHOD(drawPoint, RenderDrawPoint)               \
+  METHOD(drawPoints, RenderDrawPoints)             \
+  METHOD(drawRect, RenderDrawRect)                 \
+  METHOD(drawRects, RenderDrawRects)               \
+  METHOD(fillRect, RenderFillRect)                 \
+  METHOD(fillRects, RenderFillRects)               \
+  METHOD(getClipRect, RenderGetClipRect)           \
+  METHOD(getLogicalSize, RenderGetLogicalSize)     \
+  METHOD(getScale, RenderGetScale)                 \
+  METHOD(getViewport, RenderGetViewport)           \
+  METHOD(present, RenderPresent)                   \
+  METHOD(readPixels, RenderReadPixels)             \
+  METHOD(setClipRect, RenderSetClipRect)           \
+  METHOD(setLogicalSize, RenderSetLogicalSize)     \
+  METHOD(setScale, RenderSetScale)                 \
+  METHOD(setViewport, RenderSetViewport)           \
+  METHOD(targetSupported, RenderTargetSupported)   \
+  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
+  METHOD(setDrawColor, SetRenderDrawColor)         \
+  METHOD(setTarget, SetRenderTarget)
 
 #if SDL_COMPILEDVERSION < 2004
 #define SDL_CLASS_METHOD_LIST                      \
-  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
-  METHOD(getDrawColor, GetRenderDrawColor)         \
-  METHOD(getDriverInfo, GetRenderDriverInfo)       \
-  METHOD(getTarget, GetRenderTarget)               \
-  METHOD(getInfo, GetRendererInfo)                 \
-  METHOD(getOutputSize, GetRendererOutputSize)     \
-  METHOD(clear, RenderClear)                       \
-  METHOD(copy, RenderCopy)                         \
-  METHOD(copyEx, RenderCopyEx)                     \
-  METHOD(drawLine, RenderDrawLine)                 \
-  METHOD(drawLines, RenderDrawLines)               \
-  METHOD(drawPoint, RenderDrawPoint)               \
-  METHOD(drawPoints, RenderDrawPoints)             \
-  METHOD(drawRect, RenderDrawRect)                 \
-  METHOD(drawRects, RenderDrawRects)               \
-  METHOD(fillRect, RenderFillRect)                 \
-  METHOD(fillRects, RenderFillRects)               \
-  METHOD(getClipRect, RenderGetClipRect)           \
-  METHOD(getLogicalSize, RenderGetLogicalSize)     \
-  METHOD(getScale, RenderGetScale)                 \
-  METHOD(getViewport, RenderGetViewport)           \
-  METHOD(present, RenderPresent)                   \
-  METHOD(readPixels, RenderReadPixels)             \
-  METHOD(setClipRect, RenderSetClipRect)           \
-  METHOD(setLogicalSize, RenderSetLogicalSize)     \
-  METHOD(setScale, RenderSetScale)                 \
-  METHOD(setViewport, RenderSetViewport)           \
-  METHOD(targetSupported, RenderTargetSupported)   \
-  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
-  METHOD(setDrawColor, SetRenderDrawColor)         \
-  METHOD(setTarget, SetRenderTarget)
+  SDL_CLASS_METHOD_LIST_TMP
   SDL_CLASS(Renderer);
-
 #else
-
 #define SDL_CLASS_METHOD_LIST                      \
-  METHOD(getDrawBlendMode, GetRenderDrawBlendMode) \
-  METHOD(getDrawColor, GetRenderDrawColor)         \
-  METHOD(getDriverInfo, GetRenderDriverInfo)       \
-  METHOD(getTarget, GetRenderTarget)               \
-  METHOD(getInfo, GetRendererInfo)                 \
-  METHOD(getOutputSize, GetRendererOutputSize)     \
-  METHOD(clear, RenderClear)                       \
-  METHOD(copy, RenderCopy)                         \
-  METHOD(copyEx, RenderCopyEx)                     \
-  METHOD(drawLine, RenderDrawLine)                 \
-  METHOD(drawLines, RenderDrawLines)               \
-  METHOD(drawPoint, RenderDrawPoint)               \
-  METHOD(drawPoints, RenderDrawPoints)             \
-  METHOD(drawRect, RenderDrawRect)                 \
-  METHOD(drawRects, RenderDrawRects)               \
-  METHOD(fillRect, RenderFillRect)                 \
-  METHOD(fillRects, RenderFillRects)               \
-  METHOD(getClipRect, RenderGetClipRect)           \
-  METHOD(getLogicalSize, RenderGetLogicalSize)     \
-  METHOD(getScale, RenderGetScale)                 \
-  METHOD(getViewport, RenderGetViewport)           \
-  METHOD(isClipEnabled, RenderIsClipEnabled)       \
-  METHOD(present, RenderPresent)                   \
-  METHOD(readPixels, RenderReadPixels)             \
-  METHOD(setClipRect, RenderSetClipRect)           \
-  METHOD(setLogicalSize, RenderSetLogicalSize)     \
-  METHOD(setScale, RenderSetScale)                 \
-  METHOD(setViewport, RenderSetViewport)           \
-  METHOD(targetSupported, RenderTargetSupported)   \
-  METHOD(setDrawBlendMode, SetRenderDrawBlendMode) \
-  METHOD(setDrawColor, SetRenderDrawColor)         \
-  METHOD(setTarget, SetRenderTarget)
+  SDL_CLASS_METHOD_LIST_TMP                        \
+  METHOD(isClipEnabled, RenderIsClipEnabled)
   SDL_CLASS(Renderer);
 #endif
 
@@ -477,8 +412,7 @@ namespace sdl
         throw Error(strm.str());
       }
     }
-#if SDL_COMPILEDVERSION < 2004
-#define SDL_EVENTS                                                        \
+#define SDL_EVENTS_TMP                                                    \
   EVENT(SDL_CONTROLLERAXISMOTION, controllerAxisMotion, caxis);           \
   EVENT(SDL_CONTROLLERBUTTONDOWN, controllerButtonDown, cbutton);         \
   EVENT(SDL_CONTROLLERBUTTONUP, controllerButtonUp, cbutton);             \
@@ -511,42 +445,13 @@ namespace sdl
   EVENT(SDL_TEXTINPUT, textInput, text);                                  \
   EVENT(SDL_USEREVENT, userEvent, user);                                  \
   EVENT(SDL_WINDOWEVENT, windowEvent, window);
+#if SDL_COMPILEDVERSION < 2004
+#define SDL_EVENTS SDL_EVENTS_TMP
 #else
 #define SDL_EVENTS                                                        \
+  SDL_EVENTS_TMP                                                          \
   EVENT(SDL_AUDIODEVICEADDED, audioDeviceAdded, adevice);                 \
-  EVENT(SDL_AUDIODEVICEREMOVED, audioDeviceRemoved, adevice);             \
-  EVENT(SDL_CONTROLLERAXISMOTION, controllerAxisMotion, caxis);           \
-  EVENT(SDL_CONTROLLERBUTTONDOWN, controllerButtonDown, cbutton);         \
-  EVENT(SDL_CONTROLLERBUTTONUP, controllerButtonUp, cbutton);             \
-  EVENT(SDL_CONTROLLERDEVICEADDED, controllerDeviceAdded, cdevice);       \
-  EVENT(SDL_CONTROLLERDEVICEREMOVED, controllerDeviceRemoved, cdevice);   \
-  EVENT(SDL_CONTROLLERDEVICEREMAPPED, controllerDeviceRemapped, cdevice); \
-  EVENT(SDL_DOLLARGESTURE, dollarGesture, dgesture);                      \
-  EVENT(SDL_DOLLARRECORD, dollarRecord, dgesture);                        \
-  EVENT(SDL_DROPFILE, dropFile, drop);                                    \
-  EVENT(SDL_FINGERMOTION, fingerMotion, tfinger);                         \
-  EVENT(SDL_FINGERDOWN, fingerDown, tfinger);                             \
-  EVENT(SDL_FINGERUP, fingerUp, tfinger);                                 \
-  EVENT(SDL_KEYDOWN, keyDown, key);                                       \
-  EVENT(SDL_KEYUP, keyUp, key);                                           \
-  EVENT(SDL_JOYAXISMOTION, joyAxisMotion, jaxis);                         \
-  EVENT(SDL_JOYBALLMOTION, joyBallMotion, jball);                         \
-  EVENT(SDL_JOYHATMOTION, joyHatMotion, jhat);                            \
-  EVENT(SDL_JOYBUTTONDOWN, joyButtonDown, jbutton);                       \
-  EVENT(SDL_JOYBUTTONUP, joyButtonUp, jbutton);                           \
-  EVENT(SDL_JOYDEVICEADDED, joyDeviceAdded, jdevice);                     \
-  EVENT(SDL_JOYDEVICEREMOVED, joyDeviceRemoved, jdevice);                 \
-  EVENT(SDL_MOUSEMOTION, mouseMotion, motion);                            \
-  EVENT(SDL_MOUSEBUTTONDOWN, mouseButtonDown, button);                    \
-  EVENT(SDL_MOUSEBUTTONUP, mouseButtonUp, button);                        \
-  EVENT(SDL_MOUSEWHEEL, mouseWheel, wheel);                               \
-  EVENT(SDL_MULTIGESTURE, multiGesture, mgesture);                        \
-  EVENT(SDL_QUIT, quit, quit);                                            \
-  EVENT(SDL_SYSWMEVENT, sysWmEvent, syswm);                               \
-  EVENT(SDL_TEXTEDITING, textEditing, edit);                              \
-  EVENT(SDL_TEXTINPUT, textInput, text);                                  \
-  EVENT(SDL_USEREVENT, userEvent, user);                                  \
-  EVENT(SDL_WINDOWEVENT, windowEvent, window);
+  EVENT(SDL_AUDIODEVICEREMOVED, audioDeviceRemoved, adevice);
 #endif
 
 #define EVENT(x, y, z) std::function<void(const decltype(SDL_Event::z) &)> y

--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -23,7 +23,13 @@ SOFTWARE.
 */
 
 #pragma once
+
+#define USE_SDLGFX
+
 #include <SDL.h>
+#ifdef USE_SDLGFX
+#include <SDL2_gfxPrimitives.h>
+#endif
 #include <functional>
 #include <sstream>
 
@@ -125,12 +131,13 @@ namespace sdl
     f(args...);
   }
 
-#define METHOD(X, Y)                                       \
+#define METHOD2(X, Y)                                      \
   template <typename... Args>                              \
-  auto X(Args... args)->decltype(SDL_##Y(handle, args...)) \
+  auto X(Args... args)->decltype(Y(handle, args...))       \
   {                                                        \
-    return callSdl(SDL_##Y, handle, args...);              \
+    return callSdl(Y, handle, args...);                    \
   }
+#define METHOD(X, Y) METHOD2(X, SDL_##Y)
 
 #define SDL_CLASS_METHOD_LIST_TMP                \
   METHOD(glCreateContext, GL_CreateContext)      \
@@ -219,13 +226,83 @@ namespace sdl
   METHOD(setDrawColor, SetRenderDrawColor)         \
   METHOD(setTarget, SetRenderTarget)
 
+#ifdef USE_SDLGFX
+  #define SDLGFX_METHOD_LIST                       \
+    METHOD2(pixelColor, ::pixelColor) \
+    METHOD2(pixelRGBA, ::pixelRGBA) \
+    METHOD2(hlineColor, ::hlineColor) \
+    METHOD2(hlineRGBA, ::hlineRGBA) \
+    METHOD2(vlineColor, ::vlineColor) \
+    METHOD2(vlineRGBA, ::vlineRGBA) \
+    METHOD2(rectangleColor, ::rectangleColor) \
+    METHOD2(rectangleRGBA, ::rectangleRGBA) \
+    METHOD2(roundedRectangleColor, ::roundedRectangleColor) \
+    METHOD2(roundedRectangleRGBA, ::roundedRectangleRGBA) \
+    METHOD2(boxColor, ::boxColor) \
+    METHOD2(boxRGBA, ::boxRGBA) \
+    METHOD2(roundedBoxColor, ::roundedBoxColor) \
+    METHOD2(roundedBoxRGBA, ::roundedBoxRGBA) \
+    METHOD2(lineColor, ::lineColor) \
+    METHOD2(lineRGBA, ::lineRGBA) \
+    METHOD2(aalineColor, ::aalineColor) \
+    METHOD2(aalineRGBA, ::aalineRGBA) \
+    METHOD2(thickLineColor, ::thickLineColor) \
+    METHOD2(thickLineRGBA, ::thickLineRGBA) \
+    METHOD2(circleColor, ::circleColor) \
+    METHOD2(circleRGBA, ::circleRGBA) \
+    METHOD2(arcColor, ::arcColor) \
+    METHOD2(arcRGBA, ::arcRGBA) \
+    METHOD2(aacircleColor, ::aacircleColor) \
+    METHOD2(aacircleRGBA, ::aacircleRGBA) \
+    METHOD2(filledCircleColor, ::filledCircleColor) \
+    METHOD2(filledCircleRGBA, ::filledCircleRGBA) \
+    METHOD2(ellipseColor, ::ellipseColor) \
+    METHOD2(ellipseRGBA, ::ellipseRGBA) \
+    METHOD2(aaellipseColor, ::aaellipseColor) \
+    METHOD2(aaellipseRGBA, ::aaellipseRGBA) \
+    METHOD2(filledEllipseColor, ::filledEllipseColor) \
+    METHOD2(filledEllipseRGBA, ::filledEllipseRGBA) \
+    METHOD2(pieColor, ::pieColor) \
+    METHOD2(pieRGBA, ::pieRGBA) \
+    METHOD2(filledPieColor, ::filledPieColor) \
+    METHOD2(filledPieRGBA, ::filledPieRGBA) \
+    METHOD2(trigonColor, ::trigonColor) \
+    METHOD2(trigonRGBA, ::trigonRGBA) \
+    METHOD2(aatrigonColor, ::aatrigonColor) \
+    METHOD2(aatrigonRGBA, ::aatrigonRGBA) \
+    METHOD2(filledTrigonColor, ::filledTrigonColor) \
+    METHOD2(filledTrigonRGBA, ::filledTrigonRGBA) \
+    METHOD2(polygonColor, ::polygonColor) \
+    METHOD2(polygonRGBA, ::polygonRGBA) \
+    METHOD2(aapolygonColor, ::aapolygonColor) \
+    METHOD2(aapolygonRGBA, ::aapolygonRGBA) \
+    METHOD2(filledPolygonColor, ::filledPolygonColor) \
+    METHOD2(filledPolygonRGBA, ::filledPolygonRGBA) \
+    METHOD2(texturedPolygon, ::texturedPolygon) \
+    METHOD2(bezierColor, ::bezierColor) \
+    METHOD2(bezierRGBA, ::bezierRGBA) \
+    METHOD2(characterColor, ::characterColor) \
+    METHOD2(characterRGBA, ::characterRGBA) \
+    METHOD2(stringColor, ::stringColor) \
+    METHOD2(stringRGBA, ::stringRGBA) \
+    int stringColor(Sint16 x, Sint16 y, const std::string& str, Uint32 color) \
+      { return stringColor(x,y, str.c_str(), color); } \
+    int stringRGBA(Sint16 x, Sint16 y, const std::string& str, Uint8 r, Uint8 g, Uint8 b, Uint8 a) \
+      { return stringRGBA(x,y, str.c_str(), r,g,b,a); }
+
+#else
+  #define SDLGFX_METHOD_LIST
+#endif
+
 #if SDL_COMPILEDVERSION < 2004
 #define SDL_CLASS_METHOD_LIST                      \
-  SDL_CLASS_METHOD_LIST_TMP
+  SDL_CLASS_METHOD_LIST_TMP                        \
+  SDLGFX_METHOD_LIST                               \
   SDL_CLASS(Renderer);
 #else
 #define SDL_CLASS_METHOD_LIST                      \
   SDL_CLASS_METHOD_LIST_TMP                        \
+  SDLGFX_METHOD_LIST                               \
   METHOD(isClipEnabled, RenderIsClipEnabled)
   SDL_CLASS(Renderer);
 #endif

--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -298,7 +298,7 @@ namespace sdl
 #if SDL_COMPILEDVERSION < 2004
 #define SDL_CLASS_METHOD_LIST                      \
   SDL_CLASS_METHOD_LIST_TMP                        \
-  SDLGFX_METHOD_LIST                               \
+  SDLGFX_METHOD_LIST
   SDL_CLASS(Renderer);
 #else
 #define SDL_CLASS_METHOD_LIST                      \

--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -24,7 +24,8 @@ SOFTWARE.
 
 #pragma once
 
-#define USE_SDLGFX
+// enable this if you want to use the higher-level SDL2_gfx features
+//#define USE_SDLGFX
 
 #include <SDL.h>
 #ifdef USE_SDLGFX


### PR DESCRIPTION
Adds optional support for the higher-level GFX Primitives (like filled circles, rounded rectangles, text drawing) from SDL2_gfx. Support can be turned on and off with the `USE_SDLGFX` define (default: on).

If turned off, there is no additional dependency.

This builds upon my code deduplication pull request #4.