### PR TITLE
Enable an easier access to SDL_Surface's fields

### DIFF
--- a/sdlpp.hpp
+++ b/sdlpp.hpp
@@ -381,6 +381,8 @@ namespace sdl
     ~Surface() { SDL_FreeSurface(handle); }
     SDL_Surface *get() { return handle; }
     const SDL_Surface *get() const { return handle; }
+    SDL_Surface *operator->() { return handle; }
+    const SDL_Surface *operator->() const { return handle; }
 
   private:
     SDL_Surface *handle;


### PR DESCRIPTION
surface->h vs surface.get()->h

I can add the same to `SDL_CLASS` but I don't know SDL enough yet to say whether other classes need field access or not.